### PR TITLE
Reduce TFLite WASM memory footprint for Echo Show 8

### DIFF
--- a/scripts/copy-tflite.js
+++ b/scripts/copy-tflite.js
@@ -5,6 +5,10 @@
  * microWakeWord inference. Includes SIMD and non-SIMD variants
  * (the runtime auto-detects browser capabilities).
  *
+ * Patches the JS glue files to reduce WASM memory for low-memory
+ * devices (e.g. Echo Show 8). The default 32MB initial heap is far
+ * more than needed for tiny wake word models (50–80KB each).
+ *
  * Run automatically via npm prebuild/predev hooks.
  */
 const fs = require('fs');
@@ -21,6 +25,39 @@ const FILES = [
   'tflite_web_api_cc.wasm',
 ];
 
+// Reduced WASM memory settings for low-memory devices.
+// Default: INITIAL_MEMORY = 33554432 (32MB), getHeapMax = 2147483648 (2GB).
+// Wake word models are 50–80KB each; TFLite interpreter needs ~2–4MB total.
+// 8MB initial with 128MB cap is plenty and avoids OOM on constrained devices.
+const PATCHED_INITIAL_MEMORY = 8388608;   // 8MB (was 32MB)
+const PATCHED_MAX_HEAP = 134217728;       // 128MB (was 2GB)
+
+/**
+ * Patch WASM JS glue to reduce memory footprint.
+ * - Lowers INITIAL_MEMORY (initial WebAssembly.Memory allocation)
+ * - Caps getHeapMax() (maximum memory growth)
+ */
+function patchWasmGlue(code) {
+  let patched = code;
+  let changes = 0;
+
+  // Patch INITIAL_MEMORY: var INITIAL_MEMORY=Module["INITIAL_MEMORY"]||33554432
+  const initMemRe = /(var INITIAL_MEMORY=Module\["INITIAL_MEMORY"\]\|\|)\d+/;
+  if (initMemRe.test(patched)) {
+    patched = patched.replace(initMemRe, `$1${PATCHED_INITIAL_MEMORY}`);
+    changes++;
+  }
+
+  // Patch getHeapMax: function getHeapMax(){return 2147483648}
+  const heapMaxRe = /(function getHeapMax\(\)\{return )\d+(\})/;
+  if (heapMaxRe.test(patched)) {
+    patched = patched.replace(heapMaxRe, `$1${PATCHED_MAX_HEAP}$2`);
+    changes++;
+  }
+
+  return { patched, changes };
+}
+
 // Create destination directory
 if (!fs.existsSync(DEST)) {
   fs.mkdirSync(DEST, { recursive: true });
@@ -35,9 +72,18 @@ for (const file of FILES) {
     process.exit(1);
   }
 
-  fs.copyFileSync(src, dest);
-  const size = (fs.statSync(dest).size / 1024).toFixed(0);
-  console.log(`  ${file} (${size}KB)`);
+  // Patch JS glue files to reduce WASM memory
+  if (file.endsWith('.js') && file.startsWith('tflite_web_api_cc')) {
+    const code = fs.readFileSync(src, 'utf8');
+    const { patched, changes } = patchWasmGlue(code);
+    fs.writeFileSync(dest, patched);
+    const size = (fs.statSync(dest).size / 1024).toFixed(0);
+    console.log(`  ${file} (${size}KB) — ${changes} memory patches applied`);
+  } else {
+    fs.copyFileSync(src, dest);
+    const size = (fs.statSync(dest).size / 1024).toFixed(0);
+    console.log(`  ${file} (${size}KB)`);
+  }
 }
 
 console.log('TFLite WASM files copied.');

--- a/src/wake-word/index.js
+++ b/src/wake-word/index.js
@@ -13,7 +13,7 @@
 import { State, BlurReason } from '../constants.js';
 import { getSwitchState, getSelectState } from '../shared/satellite-state.js';
 import { CHIME_WAKE } from '../audio/chime.js';
-import { loadTFLite, loadMicroModels, loadMicroModel, getMicroModelParams, releaseUnusedMicroModels, releaseMicroModels } from './micro-models.js';
+import { loadTFLite, loadMicroModels, loadMicroModel, getMicroModelParams, releaseUnusedMicroModels, releaseMicroModels, releaseMicroModel } from './micro-models.js';
 import { MicroWakeWordInference } from './micro-inference.js';
 import { clearNotificationUI } from '../shared/satellite-notification.js';
 import { sendAck } from '../shared/notification-comms.js';
@@ -455,21 +455,17 @@ export class WakeWordManager {
     try {
       if (!this._tfweb) return;
 
-      if (!this._stopMicroConfig) {
-        this._log.log('stop-word', 'Loading stop model...');
-        const runner = await loadMicroModel(this._tfweb, 'stop');
-        const params = getMicroModelParams('stop');
-        this._stopMicroConfig = {
-          runner,
-          name: 'stop',
-          cutoff: this.getThresholdForModel('stop'),
-          slidingWindow: params.slidingWindow,
-          stepSize: params.stepSize,
-        };
-        this._log.log('stop-word', `Stop model loaded (c=${this._stopMicroConfig.cutoff})`);
-      } else {
-        this._log.log('stop-word', 'Stop model already loaded (cached)');
-      }
+      this._log.log('stop-word', 'Loading stop model...');
+      const runner = await loadMicroModel(this._tfweb, 'stop');
+      const params = getMicroModelParams('stop');
+      this._stopMicroConfig = {
+        runner,
+        name: 'stop',
+        cutoff: this.getThresholdForModel('stop'),
+        slidingWindow: params.slidingWindow,
+        stepSize: params.stepSize,
+      };
+      this._log.log('stop-word', `Stop model loaded (c=${this._stopMicroConfig.cutoff})`);
 
       this._inference.addKeyword(this._stopMicroConfig);
 
@@ -494,11 +490,19 @@ export class WakeWordManager {
 
   /**
    * Disable the stop keyword model and restore regular keywords if suspended.
+   * Releases the stop model from the WASM heap to free memory on constrained devices.
    */
   disableStopModel() {
     if (!this._inference) return;
 
     this._inference.removeKeyword('stop');
+
+    // Release stop model from WASM heap — it will be re-loaded on next use.
+    // On low-memory devices, keeping unused models allocated causes pressure.
+    if (this._stopMicroConfig) {
+      releaseMicroModel('stop');
+      this._stopMicroConfig = null;
+    }
 
     if (this._stopOnlyMode) {
       this._stopOnlyMode = false;
@@ -511,9 +515,9 @@ export class WakeWordManager {
       this._sampleBufLen = 0;
       this._frameQueue.length = 0;
       this._processing = false;
-      this._log.log('stop-word', 'Disabled (stop-only mode off)');
+      this._log.log('stop-word', 'Disabled (stop-only mode off, model released)');
     } else {
-      this._log.log('stop-word', 'Disabled');
+      this._log.log('stop-word', 'Disabled (model released)');
     }
   }
 

--- a/src/wake-word/micro-inference.js
+++ b/src/wake-word/micro-inference.js
@@ -35,6 +35,7 @@ const SLEEP_CHUNKS = 30;            // ~2.4s of silence before sleeping
 // Each 80ms chunk produces ~8 feature frames. 5 chunks = 400ms of lookback,
 // enough to capture the onset of a wake word that triggered the energy gate.
 const SLEEP_BUFFER_CHUNKS = 5;
+const SLEEP_BUFFER_MAX_FRAMES = SLEEP_BUFFER_CHUNKS * 8;
 
 export class MicroWakeWordInference {
   /**
@@ -60,7 +61,10 @@ export class MicroWakeWordInference {
     this._wakeRms = energy.wake;
     this._sleeping = false;
     this._silentChunks = 0;
-    this._sleepFeatureBuffer = [];  // rolling buffer of feature frames during sleep
+    // Fixed-size ring buffer for sleep feature frames (avoids splice/push growth)
+    this._sleepFeatureBuffer = new Array(SLEEP_BUFFER_MAX_FRAMES);
+    this._sleepBufWrite = 0;
+    this._sleepBufCount = 0;
 
     // Initialize per-keyword state
     for (const cfg of keywordConfigs) {
@@ -127,7 +131,8 @@ export class MicroWakeWordInference {
       this._silentChunks++;
       if (!this._sleeping && this._silentChunks >= SLEEP_CHUNKS) {
         this._sleeping = true;
-        this._sleepFeatureBuffer = [];
+        this._sleepBufWrite = 0;
+        this._sleepBufCount = 0;
         this._log.log('wake-word', `Sleep — inference paused (rms=${rms.toFixed(4)})`);
       }
     } else if (rms >= this._wakeRms) {
@@ -142,12 +147,12 @@ export class MicroWakeWordInference {
     const features = this._frontend.feed(samples);
 
     if (this._sleeping) {
-      // Buffer features during sleep — keep a rolling window so we can
-      // replay the onset of speech when the energy gate wakes us up.
-      for (const f of features) this._sleepFeatureBuffer.push(f);
-      const maxFrames = SLEEP_BUFFER_CHUNKS * 8; // ~8 frames per 80ms chunk
-      if (this._sleepFeatureBuffer.length > maxFrames) {
-        this._sleepFeatureBuffer.splice(0, this._sleepFeatureBuffer.length - maxFrames);
+      // Buffer features during sleep — ring buffer keeps a rolling window
+      // so we can replay the onset of speech when the energy gate wakes us.
+      for (const f of features) {
+        this._sleepFeatureBuffer[this._sleepBufWrite] = f;
+        this._sleepBufWrite = (this._sleepBufWrite + 1) % SLEEP_BUFFER_MAX_FRAMES;
+        if (this._sleepBufCount < SLEEP_BUFFER_MAX_FRAMES) this._sleepBufCount++;
       }
       return { detected: false, score: 0, vadScore: 0, model: null };
     }
@@ -156,10 +161,19 @@ export class MicroWakeWordInference {
     // of the audio that triggered the energy gate wake-up.
     let allFeatures = features;
     let replayCount = 0;
-    if (this._sleepFeatureBuffer.length > 0) {
-      replayCount = this._sleepFeatureBuffer.length;
-      allFeatures = this._sleepFeatureBuffer.concat(features);
-      this._sleepFeatureBuffer = [];
+    if (this._sleepBufCount > 0) {
+      replayCount = this._sleepBufCount;
+      // Drain ring buffer in order (oldest first)
+      const buffered = new Array(replayCount);
+      let readIdx = (this._sleepBufWrite - this._sleepBufCount + SLEEP_BUFFER_MAX_FRAMES) % SLEEP_BUFFER_MAX_FRAMES;
+      for (let i = 0; i < replayCount; i++) {
+        buffered[i] = this._sleepFeatureBuffer[readIdx];
+        this._sleepFeatureBuffer[readIdx] = null; // release ref
+        readIdx = (readIdx + 1) % SLEEP_BUFFER_MAX_FRAMES;
+      }
+      this._sleepBufWrite = 0;
+      this._sleepBufCount = 0;
+      allFeatures = buffered.concat(features);
     }
 
     if (allFeatures.length === 0) {
@@ -345,7 +359,8 @@ export class MicroWakeWordInference {
     this._frontend.reset();
     this._sleeping = false;
     this._silentChunks = 0;
-    this._sleepFeatureBuffer = [];
+    this._sleepBufWrite = 0;
+    this._sleepBufCount = 0;
     // Preserve _lastDetectionTime — the 2s cooldown prevents false
     // re-detection from stale model state (VarHandle ring buffers persist).
     for (const kw of this._keywords) {

--- a/src/wake-word/micro-models.js
+++ b/src/wake-word/micro-models.js
@@ -114,9 +114,13 @@ export async function loadMicroModel(tfweb, modelName, onProgress) {
   const filename = TFLITE_KEYWORD_FILES[modelName] || modelName;
   if (onProgress) onProgress(modelName);
 
-  // Load model and companion JSON in parallel
+  // Load model and companion JSON in parallel.
+  // numThreads: 1 avoids spawning Web Workers — each worker receives a copy
+  // of the WASM module and shares memory, adding overhead that constrained
+  // devices (e.g. Echo Show 8) cannot afford. Wake word models are tiny
+  // (~50–80KB) and single-threaded inference is fast enough (<2ms per call).
   const [runner] = await Promise.all([
-    tfweb.TFLiteWebModelRunner.create(`${MODELS_BASE}/${filename}.tflite`),
+    tfweb.TFLiteWebModelRunner.create(`${MODELS_BASE}/${filename}.tflite`, { numThreads: 1 }),
     _loadModelManifest(filename),
   ]);
   _modelCache[modelName] = runner;
@@ -175,4 +179,16 @@ export async function releaseMicroModels() {
     try { runner.cleanUp(); } catch (_) { /* ignore */ }
   }
   _modelCache = {};
+}
+
+/**
+ * Release a single model by name.
+ * @param {string} modelName
+ */
+export function releaseMicroModel(modelName) {
+  const runner = _modelCache[modelName];
+  if (runner) {
+    try { runner.cleanUp(); } catch (_) { /* ignore */ }
+    delete _modelCache[modelName];
+  }
 }


### PR DESCRIPTION
- Patch WASM glue to reduce initial memory from 32MB to 8MB
- Cap max heap growth at 128MB (was 2GB)
- Force single-threaded inference (numThreads: 1)
- Release stop model from WASM heap after each use
- Replace sleep buffer array with fixed-size ring buffer